### PR TITLE
(GH-117) Fix blacklist entry for Cake.Tasks.* addins

### DIFF
--- a/Source/Cake.AddinDiscoverer/exclusionlist.json
+++ b/Source/Cake.AddinDiscoverer/exclusionlist.json
@@ -20,7 +20,7 @@
     "Cake.SendMail", // This is a clone of Cake.Email
     "Cake.ServiceOrchestration",
     "Cake.Storm.*",
-    "Cake.Task.*",
+    "Cake.Tasks.*",
     "Cake.Testing",
     "Cake.Tin",
     "Cake.Xamarin.Build",


### PR DESCRIPTION
Fix blacklist entry for Cake.Tasks.* addins

Fixes #117 