### PR TITLE
Add Cake.Sitecore to blacklist

### DIFF
--- a/Source/Cake.AddinDiscoverer/exclusionlist.json
+++ b/Source/Cake.AddinDiscoverer/exclusionlist.json
@@ -21,6 +21,7 @@
     "Cake.Scripting.Transport",
     "Cake.SendMail", // This is a clone of Cake.Email
     "Cake.ServiceOrchestration",
+    "Cake.Sitecore",
     "Cake.Storm.*",
     "Cake.Tasks.*",
     "Cake.Testing",


### PR DESCRIPTION
Add Cake.Sitecore to blacklist since it is not an addin but a recipe script.

It is recognized as addin, since it contains some tools. A better way than blacklisting would be to improve detection of recipe packages.