### PR TITLE
Ignore Cake-Contrib label

### DIFF
--- a/Source/Cake.AddinDiscoverer/exclusionlist.json
+++ b/Source/Cake.AddinDiscoverer/exclusionlist.json
@@ -33,6 +33,7 @@
     "Addins",
     "Build",
     "Cake",
-    "Script"
+    "Script",
+    "Cake-Contrib"
   ]
 }


### PR DESCRIPTION
Ignore Cake-Contrib label, as e.g set on https://www.nuget.org/packages/Cake.SonarResults