### PR TITLE
Fix documentation for processing of categories on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ As of version 3.4.0 we have automated the following:
       | Repository  | Updated                      |
       | Author      | Not updated                  |
       | Description | Only line endings normalized |
-      | Categories  | Updated                      |
+      | Categories  | Only content normalized      |
     - Delete YAML file when addin package is removed from nuget
     - Create issue and submit PR in `cake-build/website` with all the deleted/modified/created YAML files
     - PR must be reviewed by Cake staff


### PR DESCRIPTION
Based on https://github.com/pascalberger/Cake.AddinDiscoverer/blob/6c282e8ab67f88b89862569709df4e6d931ebdc8/Source/Cake.AddinDiscoverer/Steps/SynchronizeYamlStep.cs#L259 categories are not updated for existing addins. Fix documentation to match implementation.