### PR TITLE
Avoid whitespace for empty lines in description

### DIFF
--- a/Source/Cake.AddinDiscoverer/Steps/SynchronizeYamlStep.cs
+++ b/Source/Cake.AddinDiscoverer/Steps/SynchronizeYamlStep.cs
@@ -301,7 +301,7 @@ namespace Cake.AddinDiscoverer.Steps
 				var lines = value
 					.Replace("\r\n", "\n")
 					.Split('\n')
-					.Select(line => $"  {line}");
+					.Select(line => string.IsNullOrWhiteSpace(line) ? string.Empty : $"  {line}");
 				return "|-\n" + string.Join('\n', lines);
 			}
 			else


### PR DESCRIPTION
Avoid whitespace for empty lines in description as they are not required for proper rendering on website and getting rid of them avoids conflicts with editor settings which remove trailing whitespace.