### PR TITLE
Add Cake.DotNetTool.Module to exclusion list

### DIFF
--- a/Source/Cake.AddinDiscoverer/exclusionlist.json
+++ b/Source/Cake.AddinDiscoverer/exclusionlist.json
@@ -11,6 +11,7 @@
     "Cake.CompressionNetStandard",
     "Cake.Core",
     "Cake.CoreCLR",
+    "Cake.DotNetTool.Module", // Shipped as part of Cake since 1.1
     "Cake.Email.Common",
     "Cake.Frosting",
     "Cake.Frosting.Template",


### PR DESCRIPTION
Since Cake.DotNetTool.Module now ships with Cake (https://github.com/cake-build/cake/issues/2903), we should no longer treat it as a community module.