### PR TITLE
Remove Cake Watch Advance 

### DIFF
--- a/Source/Cake.AddinDiscoverer/exclusionlist.json
+++ b/Source/Cake.AddinDiscoverer/exclusionlist.json
@@ -50,7 +50,7 @@
     "Cake.Xrm.Sdk",
     "Cake.Xrm.SolutionPackager",
     "Cake.Xrm.Spkl",
-    "Cake.Watch_Advance"
+    "Cake.Watch_Advance" // This is a clone of Cake.Watch
   ],
   "labels": [
     "Addin",

--- a/Source/Cake.AddinDiscoverer/exclusionlist.json
+++ b/Source/Cake.AddinDiscoverer/exclusionlist.json
@@ -49,7 +49,8 @@
     "Cake.Xrm.DataMigration",
     "Cake.Xrm.Sdk",
     "Cake.Xrm.SolutionPackager",
-    "Cake.Xrm.Spkl"
+    "Cake.Xrm.Spkl",
+    "Cake.Watch_Advance"
   ],
   "labels": [
     "Addin",


### PR DESCRIPTION
Related to[ this issue](https://github.com/cake-build/website/issues/2116) from the Cake-Build website repository.

Following the specifications, Cake.Watch_Advance was added to the exclusion list.

This is the first step out of two to remove Cake.Watch_Advance from the website component.

@pascalberger 